### PR TITLE
Added continuum levels to derive reaction identifiers from ENDF

### DIFF
--- a/src/elementary/ReactionNumber.hpp
+++ b/src/elementary/ReactionNumber.hpp
@@ -7,6 +7,7 @@
 
 // other includes
 #include "elementary/src/tolower.hpp"
+#include "elementary/Level.hpp"
 #include "elementary/ParticleID.hpp"
 
 namespace njoy {

--- a/src/elementary/ReactionNumber/src/register.hpp
+++ b/src/elementary/ReactionNumber/src/register.hpp
@@ -13,6 +13,7 @@ ReactionNumber::mt_dictionary{
     ParticleID h( "he3" );
     ParticleID a( "he4" );
     ParticleID g( "photon" );
+    auto continuum = Level::continuum;
 
     return
     std::map< ReactionNumber::Number, ReactionNumber::Entry > {
@@ -85,7 +86,7 @@ ReactionNumber::mt_dictionary{
       { 88, ReactionNumber::Entry{ 88, "z,n38", { "n,n'(38)", "n,n38", "z,n'(38)" }, { n }, 38 } },
       { 89, ReactionNumber::Entry{ 89, "z,n39", { "n,n'(39)", "n,n39", "z,n'(39)" }, { n }, 39 } },
       { 90, ReactionNumber::Entry{ 90, "z,n40", { "n,n'(40)", "n,n40", "z,n'(40)" }, { n }, 40 } },
-      //{ 91, ReactionNumber::Entry{ "mt": 91, "z,nc", { "n,n'(c)", "n,nc", "z,n'(c)" }, { n } } },
+      { 91, ReactionNumber::Entry{ 91, "z,nc", { "n,n'(c)", "n,nc", "z,n'(c)" }, { n }, continuum } },
       { 102, ReactionNumber::Entry{ 102, "capture", { "n,g", "n,gamma", "z,g", "z,gamma" }, { g } } },
       { 103, ReactionNumber::Entry{ 103, "z,p", { "n,p", "n,proton", "z,proton" }, { p } } },
       { 104, ReactionNumber::Entry{ 104, "z,d", { "n,d", "n,deuteron", "z,deuteron" }, { d } } },
@@ -199,7 +200,7 @@ ReactionNumber::mt_dictionary{
       { 646, ReactionNumber::Entry{ 646, "z,p46", { "n,p46" }, { p }, 46 } },
       { 647, ReactionNumber::Entry{ 647, "z,p47", { "n,p47" }, { p }, 47 } },
       { 648, ReactionNumber::Entry{ 648, "z,p48", { "n,p48" }, { p }, 48 } },
-      //{ 649, ReactionNumber::Entry{ 649, "z,pc", { "n,pc" }, { p } } },
+      { 649, ReactionNumber::Entry{ 649, "z,pc", { "n,pc" }, { p }, continuum } },
       { 650, ReactionNumber::Entry{ 650, "z,d0", { "n,d0" }, { d }, 0 } },
       { 651, ReactionNumber::Entry{ 651, "z,d1", { "n,d1" }, { d }, 1 } },
       { 652, ReactionNumber::Entry{ 652, "z,d2", { "n,d2" }, { d }, 2 } },
@@ -249,7 +250,7 @@ ReactionNumber::mt_dictionary{
       { 696, ReactionNumber::Entry{ 656, "z,d46", { "n,d46" }, { d }, 46 } },
       { 697, ReactionNumber::Entry{ 657, "z,d47", { "n,d47" }, { d }, 47 } },
       { 698, ReactionNumber::Entry{ 658, "z,d48", { "n,d48" }, { d }, 48 } },
-      //{ 699, ReactionNumber::Entry{ 699, "z,dc", { "n,dc" }, { d } } },
+      { 699, ReactionNumber::Entry{ 699, "z,dc", { "n,dc" }, { d }, continuum } },
       { 700, ReactionNumber::Entry{ 700, "z,t0", { "n,t0" }, { t }, 0 } },
       { 701, ReactionNumber::Entry{ 701, "z,t1", { "n,t1" }, { t }, 1 } },
       { 702, ReactionNumber::Entry{ 702, "z,t2", { "n,t2" }, { t }, 2 } },
@@ -299,7 +300,7 @@ ReactionNumber::mt_dictionary{
       { 746, ReactionNumber::Entry{ 746, "z,t46", { "n,t46" }, { t }, 46 } },
       { 747, ReactionNumber::Entry{ 747, "z,t47", { "n,t47" }, { t }, 47 } },
       { 748, ReactionNumber::Entry{ 748, "z,t48", { "n,t48" }, { t }, 48 } },
-      //{ 749, ReactionNumber::Entry{ 749, "z,tc", { "n,tc" }, { t } } },
+      { 749, ReactionNumber::Entry{ 749, "z,tc", { "n,tc" }, { t }, continuum } },
       { 750, ReactionNumber::Entry{ 750, "z,h0", { "n,h0" }, { h }, 0 } },
       { 751, ReactionNumber::Entry{ 751, "z,h1", { "n,h1" }, { h }, 1 } },
       { 752, ReactionNumber::Entry{ 752, "z,h2", { "n,h2" }, { h }, 2 } },
@@ -349,7 +350,7 @@ ReactionNumber::mt_dictionary{
       { 796, ReactionNumber::Entry{ 756, "z,h46", { "n,h46" }, { h }, 46 } },
       { 797, ReactionNumber::Entry{ 757, "z,h47", { "n,h47" }, { h }, 47 } },
       { 798, ReactionNumber::Entry{ 758, "z,h48", { "n,h48" }, { h }, 48 } },
-      //{ 799, ReactionNumber::Entry{ 799, "z,hc", { "n,hc" }, { h } } },
+      { 799, ReactionNumber::Entry{ 799, "z,hc", { "n,hc" }, { h }, continuum } },
       { 800, ReactionNumber::Entry{ 800, "z,a0", { "n,a0" }, { a }, 0 } },
       { 801, ReactionNumber::Entry{ 801, "z,a1", { "n,a1" }, { a }, 1 } },
       { 802, ReactionNumber::Entry{ 802, "z,a2", { "n,a2" }, { a }, 2 } },
@@ -399,7 +400,7 @@ ReactionNumber::mt_dictionary{
       { 846, ReactionNumber::Entry{ 846, "z,a46", { "n,a46" }, { a }, 46 } },
       { 847, ReactionNumber::Entry{ 847, "z,a47", { "n,a47" }, { a }, 47 } },
       { 848, ReactionNumber::Entry{ 848, "z,a48", { "n,a48" }, { a }, 48 } },
-      //{ 849, ReactionNumber::Entry{ 849, "z,ac", { "n,ac" }, { a } } },
+      { 849, ReactionNumber::Entry{ 849, "z,ac", { "n,ac" }, { a }, continuum } },
       { 875, ReactionNumber::Entry{ 875, "z,2n0", { "n,2n0" }, { n, n }, 0 } },
       { 876, ReactionNumber::Entry{ 876, "z,2n1", { "n,2n1" }, { n, n }, 1 } },
       { 877, ReactionNumber::Entry{ 877, "z,2n2", { "n,2n2" }, { n, n }, 2 } },

--- a/src/elementary/ReactionNumber/src/register.hpp
+++ b/src/elementary/ReactionNumber/src/register.hpp
@@ -416,8 +416,8 @@ ReactionNumber::mt_dictionary{
       { 887, ReactionNumber::Entry{ 887, "z,2n12", { "n,2n12" }, { n, n }, 12 } },
       { 888, ReactionNumber::Entry{ 888, "z,2n13", { "n,2n13" }, { n, n }, 13 } },
       { 889, ReactionNumber::Entry{ 889, "z,2n14", { "n,2n14" }, { n, n }, 14 } },
-      { 890, ReactionNumber::Entry{ 890, "z,2n15", { "n,2n15" }, { n, n }, 15 } }//,
-      //{ 891, ReactionNumber::Entry{ 891, "z,2nc", { "n,2nc" }, { n, n } } }
+      { 890, ReactionNumber::Entry{ 890, "z,2n15", { "n,2n15" }, { n, n }, 15 } },
+      { 891, ReactionNumber::Entry{ 891, "z,2nc", { "n,2nc" }, { n, n }, continuum } }
   }; }()
 };
 

--- a/src/elementary/test/elementary.test.cpp
+++ b/src/elementary/test/elementary.test.cpp
@@ -443,6 +443,23 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 847 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 848 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 849 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55" ) == fromEndfReactionNumber( neutron, Fe56_e0, 875 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 876 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e2" ) == fromEndfReactionNumber( neutron, Fe56_e0, 877 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e3" ) == fromEndfReactionNumber( neutron, Fe56_e0, 878 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e4" ) == fromEndfReactionNumber( neutron, Fe56_e0, 879 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e5" ) == fromEndfReactionNumber( neutron, Fe56_e0, 880 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e6" ) == fromEndfReactionNumber( neutron, Fe56_e0, 881 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e7" ) == fromEndfReactionNumber( neutron, Fe56_e0, 882 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e8" ) == fromEndfReactionNumber( neutron, Fe56_e0, 883 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e9" ) == fromEndfReactionNumber( neutron, Fe56_e0, 884 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e10" ) == fromEndfReactionNumber( neutron, Fe56_e0, 885 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e11" ) == fromEndfReactionNumber( neutron, Fe56_e0, 886 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e12" ) == fromEndfReactionNumber( neutron, Fe56_e0, 887 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e13" ) == fromEndfReactionNumber( neutron, Fe56_e0, 888 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e14" ) == fromEndfReactionNumber( neutron, Fe56_e0, 889 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55_e15" ) == fromEndfReactionNumber( neutron, Fe56_e0, 890 ) );
+      CHECK( ReactionID( "n,Fe56->n,n,Fe55[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 891 ) );
 
       // incident protons
       CHECK( ReactionID( "p,Fe56->p,Fe56" ) == fromEndfReactionNumber( proton, Fe56_e0, 2 ) );
@@ -749,6 +766,23 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 847 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 848 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 849 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55" ) == fromEndfReactionNumber( proton, Fe56_e0, 875 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 876 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e2" ) == fromEndfReactionNumber( proton, Fe56_e0, 877 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e3" ) == fromEndfReactionNumber( proton, Fe56_e0, 878 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e4" ) == fromEndfReactionNumber( proton, Fe56_e0, 879 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e5" ) == fromEndfReactionNumber( proton, Fe56_e0, 880 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e6" ) == fromEndfReactionNumber( proton, Fe56_e0, 881 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e7" ) == fromEndfReactionNumber( proton, Fe56_e0, 882 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e8" ) == fromEndfReactionNumber( proton, Fe56_e0, 883 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e9" ) == fromEndfReactionNumber( proton, Fe56_e0, 884 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e10" ) == fromEndfReactionNumber( proton, Fe56_e0, 885 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e11" ) == fromEndfReactionNumber( proton, Fe56_e0, 886 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e12" ) == fromEndfReactionNumber( proton, Fe56_e0, 887 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e13" ) == fromEndfReactionNumber( proton, Fe56_e0, 888 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e14" ) == fromEndfReactionNumber( proton, Fe56_e0, 889 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55_e15" ) == fromEndfReactionNumber( proton, Fe56_e0, 890 ) );
+      CHECK( ReactionID( "p,Fe56->n,n,Co55[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 891 ) );
     } // THEN
   } // GIVEN
 } // SCENARIO

--- a/src/elementary/test/elementary.test.cpp
+++ b/src/elementary/test/elementary.test.cpp
@@ -191,6 +191,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->n,Fe56_e38" ) == fromEndfReactionNumber( neutron, Fe56_e0, 88 ) );
       CHECK( ReactionID( "n,Fe56->n,Fe56_e39" ) == fromEndfReactionNumber( neutron, Fe56_e0, 89 ) );
       CHECK( ReactionID( "n,Fe56->n,Fe56_e40" ) == fromEndfReactionNumber( neutron, Fe56_e0, 90 ) );
+      CHECK( ReactionID( "n,Fe56->n,Fe56[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 91 ) );
 
       CHECK( ReactionID( "n,Fe56->p,Mn56" ) == fromEndfReactionNumber( neutron, Fe56_e0, 600 ) );
       CHECK( ReactionID( "n,Fe56->p,Mn56_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 601 ) );
@@ -241,7 +242,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->p,Mn56_e46" ) == fromEndfReactionNumber( neutron, Fe56_e0, 646 ) );
       CHECK( ReactionID( "n,Fe56->p,Mn56_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 647 ) );
       CHECK( ReactionID( "n,Fe56->p,Mn56_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 648 ) );
-
+      CHECK( ReactionID( "n,Fe56->p,Mn56[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 649 ) );
       CHECK( ReactionID( "n,Fe56->h2,Mn55" ) == fromEndfReactionNumber( neutron, Fe56_e0, 650 ) );
       CHECK( ReactionID( "n,Fe56->h2,Mn55_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 651 ) );
       CHECK( ReactionID( "n,Fe56->h2,Mn55_e2" ) == fromEndfReactionNumber( neutron, Fe56_e0, 652 ) );
@@ -291,7 +292,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->h2,Mn55_e46" ) == fromEndfReactionNumber( neutron, Fe56_e0, 696 ) );
       CHECK( ReactionID( "n,Fe56->h2,Mn55_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 697 ) );
       CHECK( ReactionID( "n,Fe56->h2,Mn55_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 698 ) );
-
+      CHECK( ReactionID( "n,Fe56->h2,Mn55[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 699 ) );
       CHECK( ReactionID( "n,Fe56->h3,Mn54" ) == fromEndfReactionNumber( neutron, Fe56_e0, 700 ) );
       CHECK( ReactionID( "n,Fe56->h3,Mn54_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 701 ) );
       CHECK( ReactionID( "n,Fe56->h3,Mn54_e2" ) == fromEndfReactionNumber( neutron, Fe56_e0, 702 ) );
@@ -341,7 +342,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->h3,Mn54_e46" ) == fromEndfReactionNumber( neutron, Fe56_e0, 746 ) );
       CHECK( ReactionID( "n,Fe56->h3,Mn54_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 747 ) );
       CHECK( ReactionID( "n,Fe56->h3,Mn54_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 748 ) );
-
+      CHECK( ReactionID( "n,Fe56->h3,Mn54[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 749 ) );
       CHECK( ReactionID( "n,Fe56->he3,Cr54" ) == fromEndfReactionNumber( neutron, Fe56_e0, 750 ) );
       CHECK( ReactionID( "n,Fe56->he3,Cr54_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 751 ) );
       CHECK( ReactionID( "n,Fe56->he3,Cr54_e2" ) == fromEndfReactionNumber( neutron, Fe56_e0, 752 ) );
@@ -391,7 +392,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->he3,Cr54_e46" ) == fromEndfReactionNumber( neutron, Fe56_e0, 796 ) );
       CHECK( ReactionID( "n,Fe56->he3,Cr54_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 797 ) );
       CHECK( ReactionID( "n,Fe56->he3,Cr54_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 798 ) );
-
+      CHECK( ReactionID( "n,Fe56->he3,Cr54[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 799 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53" ) == fromEndfReactionNumber( neutron, Fe56_e0, 800 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e1" ) == fromEndfReactionNumber( neutron, Fe56_e0, 801 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e2" ) == fromEndfReactionNumber( neutron, Fe56_e0, 802 ) );
@@ -441,6 +442,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e46" ) == fromEndfReactionNumber( neutron, Fe56_e0, 846 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e47" ) == fromEndfReactionNumber( neutron, Fe56_e0, 847 ) );
       CHECK( ReactionID( "n,Fe56->he4,Cr53_e48" ) == fromEndfReactionNumber( neutron, Fe56_e0, 848 ) );
+      CHECK( ReactionID( "n,Fe56->he4,Cr53[continuum]" ) == fromEndfReactionNumber( neutron, Fe56_e0, 849 ) );
 
       // incident protons
       CHECK( ReactionID( "p,Fe56->p,Fe56" ) == fromEndfReactionNumber( proton, Fe56_e0, 2 ) );
@@ -495,6 +497,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->n,Co56_e38" ) == fromEndfReactionNumber( proton, Fe56_e0, 88 ) );
       CHECK( ReactionID( "p,Fe56->n,Co56_e39" ) == fromEndfReactionNumber( proton, Fe56_e0, 89 ) );
       CHECK( ReactionID( "p,Fe56->n,Co56_e40" ) == fromEndfReactionNumber( proton, Fe56_e0, 90 ) );
+      CHECK( ReactionID( "p,Fe56->n,Co56[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 91 ) );
 
       CHECK( ReactionID( "p,Fe56->p,Fe56" ) == fromEndfReactionNumber( proton, Fe56_e0, 600 ) );
       CHECK( ReactionID( "p,Fe56->p,Fe56_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 601 ) );
@@ -545,7 +548,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->p,Fe56_e46" ) == fromEndfReactionNumber( proton, Fe56_e0, 646 ) );
       CHECK( ReactionID( "p,Fe56->p,Fe56_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 647 ) );
       CHECK( ReactionID( "p,Fe56->p,Fe56_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 648 ) );
-
+      CHECK( ReactionID( "p,Fe56->p,Fe56[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 649 ) );
       CHECK( ReactionID( "p,Fe56->h2,Fe55" ) == fromEndfReactionNumber( proton, Fe56_e0, 650 ) );
       CHECK( ReactionID( "p,Fe56->h2,Fe55_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 651 ) );
       CHECK( ReactionID( "p,Fe56->h2,Fe55_e2" ) == fromEndfReactionNumber( proton, Fe56_e0, 652 ) );
@@ -595,7 +598,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->h2,Fe55_e46" ) == fromEndfReactionNumber( proton, Fe56_e0, 696 ) );
       CHECK( ReactionID( "p,Fe56->h2,Fe55_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 697 ) );
       CHECK( ReactionID( "p,Fe56->h2,Fe55_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 698 ) );
-
+      CHECK( ReactionID( "p,Fe56->h2,Fe55[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 699 ) );
       CHECK( ReactionID( "p,Fe56->h3,Fe54" ) == fromEndfReactionNumber( proton, Fe56_e0, 700 ) );
       CHECK( ReactionID( "p,Fe56->h3,Fe54_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 701 ) );
       CHECK( ReactionID( "p,Fe56->h3,Fe54_e2" ) == fromEndfReactionNumber( proton, Fe56_e0, 702 ) );
@@ -645,7 +648,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->h3,Fe54_e46" ) == fromEndfReactionNumber( proton, Fe56_e0, 746 ) );
       CHECK( ReactionID( "p,Fe56->h3,Fe54_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 747 ) );
       CHECK( ReactionID( "p,Fe56->h3,Fe54_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 748 ) );
-
+      CHECK( ReactionID( "p,Fe56->h3,Fe54[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 749 ) );
       CHECK( ReactionID( "p,Fe56->he3,Mn54" ) == fromEndfReactionNumber( proton, Fe56_e0, 750 ) );
       CHECK( ReactionID( "p,Fe56->he3,Mn54_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 751 ) );
       CHECK( ReactionID( "p,Fe56->he3,Mn54_e2" ) == fromEndfReactionNumber( proton, Fe56_e0, 752 ) );
@@ -695,7 +698,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->he3,Mn54_e46" ) == fromEndfReactionNumber( proton, Fe56_e0, 796 ) );
       CHECK( ReactionID( "p,Fe56->he3,Mn54_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 797 ) );
       CHECK( ReactionID( "p,Fe56->he3,Mn54_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 798 ) );
-
+      CHECK( ReactionID( "p,Fe56->he3,Mn54[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 799 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53" ) == fromEndfReactionNumber( proton, Fe56_e0, 800 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e1" ) == fromEndfReactionNumber( proton, Fe56_e0, 801 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e2" ) == fromEndfReactionNumber( proton, Fe56_e0, 802 ) );
@@ -745,6 +748,7 @@ SCENARIO( "fromEndfReactionNumber" ) {
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e46" ) == fromEndfReactionNumber( proton, Fe56_e0, 846 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e47" ) == fromEndfReactionNumber( proton, Fe56_e0, 847 ) );
       CHECK( ReactionID( "p,Fe56->he4,Mn53_e48" ) == fromEndfReactionNumber( proton, Fe56_e0, 848 ) );
+      CHECK( ReactionID( "p,Fe56->he4,Mn53[continuum]" ) == fromEndfReactionNumber( proton, Fe56_e0, 849 ) );
     } // THEN
   } // GIVEN
 } // SCENARIO


### PR DESCRIPTION
Continuum reactions now have their reaction identifier generated correctly from their ENDF MT number.