### PR TITLE
Added the resolve function to return the daughter nuclide for a reaction

### DIFF
--- a/src/elementary.hpp
+++ b/src/elementary.hpp
@@ -13,5 +13,6 @@
 // free functions to produce new identifiers
 #include "elementary/src/absorb.hpp"
 #include "elementary/src/emit.hpp"
+#include "elementary/src/resolve.hpp"
 #include "elementary/src/fromEndfReactionNumber.hpp"
 #include "elementary/src/toEndfReactionNumber.hpp"

--- a/src/elementary/ReactionID.hpp
+++ b/src/elementary/ReactionID.hpp
@@ -13,6 +13,7 @@
 #include "elementary/ParticleTupleID.hpp"
 #include "elementary/src/absorb.hpp"
 #include "elementary/src/emit.hpp"
+#include "elementary/src/resolve.hpp"
 
 namespace njoy {
 namespace elementary {

--- a/src/elementary/ReactionType.hpp
+++ b/src/elementary/ReactionType.hpp
@@ -101,6 +101,20 @@ namespace elementary {
     }
 
     /**
+     *  @brief return whether or not the reaction is a special reaction
+     *         (i.e. a reaction for which no outgoing particles are registered,
+     *         except for elastic)
+     */
+    bool isSpecial() const noexcept {
+
+      if ( this->name() == "elastic" ) {
+
+        return false;
+      }
+      return this->particles().size() == 0;
+    }
+
+    /**
      *  @brief operator<()
      *
      *  @param[in] right   the type on the right hand side

--- a/src/elementary/ReactionType/src/register.hpp
+++ b/src/elementary/ReactionType/src/register.hpp
@@ -6,6 +6,7 @@ ReactionType::name_dictionary{
 
   [] () {
 
+    ParticleID g( "g" );
     ParticleID n( "n" );
     ParticleID p( "p" );
     ParticleID d( "h2" );
@@ -27,7 +28,7 @@ ReactionType::name_dictionary{
       { ReactionType::Entry{  38, "fission[3n]",    { "fission4", "n,3nf" } } },
       { ReactionType::Entry{  27, "absorption",     { "n,absorption" } } },
       { ReactionType::Entry{ 101, "disappearance",  { "n,disappearance" } } },
-      { ReactionType::Entry{ 102, "capture",        { "n,g", "n,gamma", "z,g", "z,gamma" } } },
+      { ReactionType::Entry{ 102, "capture",        { "n,g", "n,gamma", "z,g", "z,gamma" }, { g } } },
       { ReactionType::Entry{  11, "2nd",            { "z,2nd", "n,2nd" }, { n, n, d } } },
       { ReactionType::Entry{  16, "2n(t)",          { "z,2n", "n,2n" }, { n, n } } },
       { ReactionType::Entry{  17, "3n",             { "z,3n", "n,3n" }, { n, n, n } } },

--- a/src/elementary/src/resolve.hpp
+++ b/src/elementary/src/resolve.hpp
@@ -1,0 +1,66 @@
+#ifndef NJOY_ELEMENTARY_RESOLVE
+#define NJOY_ELEMENTARY_RESOLVE
+
+// system includes
+
+// other includes
+#include "elementary/ParticleID.hpp"
+#include "elementary/ReactionType.hpp"
+#include "elementary/src/absorb.hpp"
+#include "elementary/src/emit.hpp"
+
+namespace njoy {
+namespace elementary {
+
+  /**
+   *  @brief Return the particle identifier for the residual particle
+   *
+   *  @param[in] incident   the incident particle identifier
+   *  @param[in] target     the target particle identifier
+   *  @param[in] type       the reaction type
+   */
+  ParticleID resolve( const ParticleID& incident, const ParticleID& target,
+                      const ReactionType& type ) {
+
+    if ( type.name() == "elastic" ) {
+
+      return target;
+    }
+    else if ( type.isSpecial() ) {
+
+      throw std::invalid_argument(
+                "The daughter nuclide cannot be determined for the special "
+                "reaction '" + incident.symbol() + "," + target.symbol() + "->"
+                + type.name() + "'" );
+    }
+    else {
+
+      // get the emitted particles
+      std::vector< ParticleID > particles = type.particles();
+
+      // produce the residual
+      try {
+
+        auto isotope = absorb( target, incident );
+        for ( const auto& particle : particles ) {
+
+          isotope = emit( isotope, particle );
+        }
+
+        return target.isNuclide()
+                   ? ParticleID( NuclideID( isotope.za(), type.level() ) )
+                   : ParticleID( NucleusID( isotope.za(), type.level() ) );
+      }
+      catch ( const std::invalid_argument& ) {
+
+        throw std::invalid_argument(
+                  "The daughter nuclide cannot be determined for the reaction "
+                  "type '" + type.name() + "' for '" + incident.symbol() + ","
+                  + target.symbol() + "' because the reaction is impossible" );
+      }
+    }
+  }
+} // elementary namespace
+} // njoy namespace
+
+#endif

--- a/src/elementary/test/elementary.test.cpp
+++ b/src/elementary/test/elementary.test.cpp
@@ -3,6 +3,7 @@
 #include "catch.hpp"
 #include "elementary/src/absorb.hpp"
 #include "elementary/src/emit.hpp"
+#include "elementary/src/resolve.hpp"
 #include "elementary/src/join.hpp"
 #include "elementary/src/split.hpp"
 #include "elementary/src/fromEndfReactionNumber.hpp"
@@ -21,6 +22,7 @@ using namespace njoy::elementary;
 
 #include "elementary/test/absorb.test.hpp"
 #include "elementary/test/emit.test.hpp"
+#include "elementary/test/resolve.test.hpp"
 #include "elementary/test/join.test.hpp"
 #include "elementary/test/split.test.hpp"
 #include "elementary/test/fromEndfReactionNumber.test.hpp"

--- a/src/elementary/test/resolve.test.hpp
+++ b/src/elementary/test/resolve.test.hpp
@@ -1,0 +1,26 @@
+SCENARIO( "resolve" ) {
+
+  GIVEN( "valid identifiers" ) {
+
+    ParticleID in( "n" );
+    ParticleID target( "Fe56" );
+
+    ReactionType mt51( 51 );
+    ReactionType mt102( 102 );
+
+    ReactionType mt1( 1 );
+    ReactionType mt18( 1 );
+
+    THEN( "the daughter is returned for normal reactions" ) {
+
+      CHECK( ParticleID( "Fe56_e1" ) == resolve( in, target, mt51 ) );
+      CHECK( ParticleID( "Fe57" ) == resolve( in, target, mt102 ) );
+    } // THEN
+
+    THEN( "an exception is thrown for special reactions" ) {
+
+      CHECK_THROWS( resolve( in, target, mt1 ) );
+      CHECK_THROWS( resolve( in, target, mt18 ) );
+    } // THEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
This function can be used to obtain the daughter nuclide for a reaction. I will need this functionality to resolve the particle pair issue in from ENDF in resonance reconstruction.