### PR TITLE
Feature/hash

### DIFF
--- a/src/elementary/ElementID.hpp
+++ b/src/elementary/ElementID.hpp
@@ -14,6 +14,10 @@ namespace elementary {
   /**
    *  @class
    *  @brief The element identifier, with associated element symbol and name
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  element number. A hash function and override for std::hash is also
+   *  provided.
    */
   class ElementID {
 
@@ -47,6 +51,11 @@ namespace elementary {
 
       return this->z_;
     }
+
+    /**
+     *  @brief return the hash value
+     */
+    auto hash() const noexcept { return this->number(); }
 
     /**
      *  @brief return the element symbol
@@ -99,5 +108,19 @@ namespace elementary {
   #include "elementary/ElementID/src/register.hpp"
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ElementID class
+  template <>
+  struct hash< njoy::elementary::ElementID > {
+
+    size_t operator()( const njoy::elementary::ElementID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/ElementID/test/ElementID.test.cpp
+++ b/src/elementary/ElementID/test/ElementID.test.cpp
@@ -88,8 +88,7 @@ SCENARIO( "ElementID" ) {
 
       std::unordered_map< ElementID, std::string > map{
 
-        { id1, "1" },
-        { id2, "2" }
+        { id1, "1" }, { id2, "2" }
       };
 
       CHECK( map[ id1 ] == "1" );

--- a/src/elementary/ElementID/test/ElementID.test.cpp
+++ b/src/elementary/ElementID/test/ElementID.test.cpp
@@ -3,6 +3,10 @@
 #include "catch.hpp"
 #include "elementary/ElementID.hpp"
 
+// other includes
+#include <map>
+#include <unordered_map>
+
 // convenience typedefs
 using ElementID = njoy::elementary::ElementID;
 
@@ -65,6 +69,33 @@ SCENARIO( "ElementID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< ElementID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ElementID( 1 ) ] == "1" );
+      CHECK( map[ ElementID( 2 ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< ElementID, std::string > map{
+
+        { id1, "1" },
+        { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ElementID( 1 ) ] == "1" );
+      CHECK( map[ ElementID( 2 ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/FundamentalParticleID.hpp
+++ b/src/elementary/FundamentalParticleID.hpp
@@ -5,6 +5,8 @@
 #include <string>
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/src/tolower.hpp"
 
 namespace njoy {
@@ -14,6 +16,10 @@ namespace elementary {
    *  @class
    *  @brief The fundamental particle identifier, with associated symbol and
    *         name
+   *
+   *  Comparison operators are provided using a unique hash for each registered
+   *  fundamental particle type. A hash function and override for std::hash is
+   *  also provided.
    */
   class FundamentalParticleID {
 
@@ -103,5 +109,19 @@ namespace elementary {
   #include "elementary/FundamentalParticleID/src/register.hpp"
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the FundamentalParticleID class
+  template <>
+  struct hash< njoy::elementary::FundamentalParticleID > {
+
+    size_t operator()( const njoy::elementary::FundamentalParticleID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/FundamentalParticleID/test/FundamentalParticleID.test.cpp
+++ b/src/elementary/FundamentalParticleID/test/FundamentalParticleID.test.cpp
@@ -3,6 +3,10 @@
 #include "catch.hpp"
 #include "elementary/FundamentalParticleID.hpp"
 
+// other includes
+#include <map>
+#include <unordered_map>
+
 // convenience typedefs
 using FundamentalParticleID = njoy::elementary::FundamentalParticleID;
 
@@ -66,6 +70,32 @@ SCENARIO( "FundamentalParticleID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< FundamentalParticleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ FundamentalParticleID( "n" ) ] == "1" );
+      CHECK( map[ FundamentalParticleID( "p" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< FundamentalParticleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ FundamentalParticleID( "n" ) ] == "1" );
+      CHECK( map[ FundamentalParticleID( "p" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/Identifier.hpp
+++ b/src/elementary/Identifier.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ELEMENTARY_IDENTIFIER
 
 // system includes
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -13,13 +14,18 @@ namespace elementary {
   /** @class
    *  @brief The generic string identifier
    *
-   *  A generic identifier in which a string is the underlying identifier type,
-   *  implemented as a CRTP.
+   *  A generic identifier in which a string is the underlying identifier type
+   *  with an associated hash value, implemented as a CRTP.
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  string. A hash function is also provided. An override for std::hash
+   *  should be provided for each derived identifier separately.
    */
   template < typename Derived > class Identifier {
 
     /* fields */
     std::string id_;
+    std::size_t hash_;
 
     /* auxialiary functions */
     #include "elementary/Identifier/src/validate.hpp"
@@ -37,6 +43,11 @@ namespace elementary {
      *  @brief return the identifier string
      */
     const std::string& symbol() const noexcept { return this->id_; }
+
+    /**
+     *  @brief return the hash value
+     */
+    std::size_t hash() const noexcept { return this->hash_; }
 
     /**
      *  @brief operator<()

--- a/src/elementary/Identifier/src/ctor.hpp
+++ b/src/elementary/Identifier/src/ctor.hpp
@@ -5,7 +5,7 @@
  *  @param[in] validate     the optional flag to switch off validation
  */
 Identifier( const std::string& identifier, bool validate = true ) :
-  id_( identifier ) {
+  id_( identifier ), hash_( std::hash< std::string >{}( identifier ) ) {
 
   if ( validate ) { this->validate(); }
 }

--- a/src/elementary/Identifier/test/Identifier.test.cpp
+++ b/src/elementary/Identifier/test/Identifier.test.cpp
@@ -3,6 +3,10 @@
 #include "catch.hpp"
 #include "elementary/Identifier.hpp"
 
+// other includes
+#include <map>
+#include <unordered_map>
+
 // convenience typedefs
 template < typename Derived >
 using Identifier = njoy::elementary::Identifier< Derived >;
@@ -18,6 +22,20 @@ public:
 
   TestID( const std::string& identifier ) : Identifier( identifier ) {};
 };
+
+namespace std {
+
+  // std::hash override for the Identifier class
+  template <>
+  struct hash< TestID > {
+
+    size_t operator()( const TestID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 class Size5ID : public Identifier< Size5ID > {
 
@@ -64,6 +82,32 @@ SCENARIO( "Identifier" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< TestID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ TestID( "a" ) ] == "1" );
+      CHECK( map[ TestID( "b" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< TestID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ TestID( "a" ) ] == "1" );
+      CHECK( map[ TestID( "b" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/IsotopeID.hpp
+++ b/src/elementary/IsotopeID.hpp
@@ -15,6 +15,10 @@ namespace elementary {
   /**
    *  @class
    *  @brief The isotope identifier, with associated name - e.g. Fe56 or Fe
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  element and mass number. A hash function and override for std::hash is
+   *  also provided.
    */
   class IsotopeID {
 
@@ -76,6 +80,14 @@ namespace elementary {
     }
 
     /**
+     *  @brief Return the hash value associated to the isotope
+     */
+    auto hash() const noexcept {
+
+      return this->za();
+    }
+
+    /**
      *  @brief operator<()
      *
      *  @param[in] right   the identifier on the right hand side
@@ -110,5 +122,19 @@ namespace elementary {
   #include "elementary/IsotopeID/src/register.hpp"
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ElementID class
+  template <>
+  struct hash< njoy::elementary::IsotopeID > {
+
+    size_t operator()( const njoy::elementary::IsotopeID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/IsotopeID/test/IsotopeID.test.cpp
+++ b/src/elementary/IsotopeID/test/IsotopeID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/IsotopeID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ElementID.hpp"
 
 // convenience typedefs
@@ -104,6 +106,32 @@ SCENARIO( "IsotopeID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< IsotopeID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ IsotopeID( "H1" ) ] == "1" );
+      CHECK( map[ IsotopeID( "He4" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< IsotopeID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ IsotopeID( "H1" ) ] == "1" );
+      CHECK( map[ IsotopeID( "He4" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/NucleusID.hpp
+++ b/src/elementary/NucleusID.hpp
@@ -19,6 +19,10 @@ namespace elementary {
    *
    *  This identifier is the same as the nuclide identifier, except that the
    *  name is complete lower case.
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  element, mass and excited state number. A hash function and override for
+   *  std::hash is also provided.
    */
   class NucleusID : protected NuclideID {
 
@@ -94,5 +98,19 @@ namespace elementary {
   #include "elementary/NucleusID/src/register.hpp"
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the NucleusID class
+  template <>
+  struct hash< njoy::elementary::NucleusID > {
+
+    size_t operator()( const njoy::elementary::NucleusID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/NucleusID/test/NucleusID.test.cpp
+++ b/src/elementary/NucleusID/test/NucleusID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/NucleusID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ElementID.hpp"
 #include "elementary/IsotopeID.hpp"
 #include "elementary/Level.hpp"
@@ -148,6 +150,32 @@ SCENARIO( "NucleusID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< NucleusID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ NucleusID( "h1" ) ] == "1" );
+      CHECK( map[ NucleusID( "he4" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< NucleusID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ NucleusID( "h1" ) ] == "1" );
+      CHECK( map[ NucleusID( "he4" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/NuclideID.hpp
+++ b/src/elementary/NuclideID.hpp
@@ -20,6 +20,10 @@ namespace elementary {
    *
    *  Aliases like Am242m = Am242_e2 will be handled by a factory function
    *  that uses a static map for aliasing.
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  element, mass and excited state number. A hash function and override for
+   *  std::hash is also provided.
    */
   class NuclideID {
 
@@ -133,5 +137,19 @@ namespace elementary {
   #include "elementary/NuclideID/src/register.hpp"
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the NuclideID class
+  template <>
+  struct hash< njoy::elementary::NuclideID > {
+
+    size_t operator()( const njoy::elementary::NuclideID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/NuclideID/test/NuclideID.test.cpp
+++ b/src/elementary/NuclideID/test/NuclideID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/NuclideID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ElementID.hpp"
 #include "elementary/IsotopeID.hpp"
 #include "elementary/Level.hpp"
@@ -148,6 +150,32 @@ SCENARIO( "NuclideID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< NuclideID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ NuclideID( "H1" ) ] == "1" );
+      CHECK( map[ NuclideID( "He4" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< NuclideID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ NuclideID( "H1" ) ] == "1" );
+      CHECK( map[ NuclideID( "He4" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/ParticleID.hpp
+++ b/src/elementary/ParticleID.hpp
@@ -18,6 +18,9 @@ namespace elementary {
    *  @class
    *  @brief The particle identifier, either a fundamental particle, a nucleus
    *         or nuclide identifier
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  symbol. A hash function and override for std::hash is also provided.
    */
   class ParticleID {
 
@@ -155,5 +158,19 @@ namespace elementary {
   };
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ParticleID class
+  template <>
+  struct hash< njoy::elementary::ParticleID > {
+
+    size_t operator()( const njoy::elementary::ParticleID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/ParticleID/test/ParticleID.test.cpp
+++ b/src/elementary/ParticleID/test/ParticleID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/ParticleID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/FundamentalParticleID.hpp"
 #include "elementary/NucleusID.hpp"
 #include "elementary/NuclideID.hpp"
@@ -165,6 +167,32 @@ SCENARIO( "ParticleID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< ParticleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticleID( "He4_e5" ) ] == "1" );
+      CHECK( map[ ParticleID( "He4[continuum]" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< ParticleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticleID( "He4_e5" ) ] == "1" );
+      CHECK( map[ ParticleID( "He4[continuum]" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/ParticlePairID.hpp
+++ b/src/elementary/ParticlePairID.hpp
@@ -31,6 +31,9 @@ namespace elementary {
    *
    *  The order in which these are given determines which particle is
    *  considered the "particle" and which is the "residual".
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  symbol. A hash function and override for std::hash is also provided.
    */
   class ParticlePairID : public Identifier< ParticlePairID > {
 
@@ -72,5 +75,19 @@ namespace elementary {
   };
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ParticlePairID class
+  template <>
+  struct hash< njoy::elementary::ParticlePairID > {
+
+    size_t operator()( const njoy::elementary::ParticlePairID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/ParticlePairID/test/ParticlePairID.test.cpp
+++ b/src/elementary/ParticlePairID/test/ParticlePairID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/ParticlePairID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ParticleID.hpp"
 
 // convenience typedefs
@@ -60,6 +62,32 @@ SCENARIO( "ParticlePairID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< ParticlePairID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticlePairID( "n,Fe56" ) ] == "1" );
+      CHECK( map[ ParticlePairID( "n,Fe56_e1" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< ParticlePairID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticlePairID( "n,Fe56" ) ] == "1" );
+      CHECK( map[ ParticlePairID( "n,Fe56_e1" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/ParticleTupleID.hpp
+++ b/src/elementary/ParticleTupleID.hpp
@@ -31,6 +31,9 @@ namespace elementary {
    *
    *  The order in which these are given is important. The last one is
    *  considered the "residual", all others are considered "particles".
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  symbol. A hash function and override for std::hash is also provided.
    */
   class ParticleTupleID : public Identifier< ParticleTupleID > {
 
@@ -66,5 +69,19 @@ namespace elementary {
   };
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ParticleTupleID class
+  template <>
+  struct hash< njoy::elementary::ParticleTupleID > {
+
+    size_t operator()( const njoy::elementary::ParticleTupleID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/ParticleTupleID/test/ParticleTupleID.test.cpp
+++ b/src/elementary/ParticleTupleID/test/ParticleTupleID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/ParticleTupleID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ParticleID.hpp"
 
 // convenience typedefs
@@ -96,6 +98,32 @@ SCENARIO( "ParticleTupleID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< ParticleTupleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticleTupleID( "n,Fe56" ) ] == "1" );
+      CHECK( map[ ParticleTupleID( "n,Fe56_e1" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< ParticleTupleID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ParticleTupleID( "n,Fe56" ) ] == "1" );
+      CHECK( map[ ParticleTupleID( "n,Fe56_e1" ) ] == "2" );
     } // THEN
   } // GIVEN
 

--- a/src/elementary/ReactionID.hpp
+++ b/src/elementary/ReactionID.hpp
@@ -30,6 +30,9 @@ namespace elementary {
    *    - "n,Fe56->n,Fe56" for elastic neutron scattering on Fe56
    *    - "n,he4->h2,h3" for a neutron on alpha resulting in a deuteron and
    *      triton
+   *
+   *  Comparison operators are provided using the logical order given by the
+   *  symbol. A hash function and override for std::hash is also provided.
    */
   class ReactionID : public Identifier< ReactionID > {
 
@@ -80,5 +83,19 @@ namespace elementary {
   };
 } // elementary namespace
 } // njoy namespace
+
+namespace std {
+
+  // std::hash override for the ReactionID class
+  template <>
+  struct hash< njoy::elementary::ReactionID > {
+
+    size_t operator()( const njoy::elementary::ReactionID& key ) const {
+
+      return key.hash();
+    }
+  };
+
+} // namespace std
 
 #endif

--- a/src/elementary/ReactionID/test/ReactionID.test.cpp
+++ b/src/elementary/ReactionID/test/ReactionID.test.cpp
@@ -4,6 +4,8 @@
 #include "elementary/ReactionID.hpp"
 
 // other includes
+#include <map>
+#include <unordered_map>
 #include "elementary/ParticlePairID.hpp"
 #include "elementary/ParticleTupleID.hpp"
 
@@ -95,6 +97,32 @@ SCENARIO( "ParticlePairID" ) {
       CHECK( ( id2 <  id1 ) == false );
       CHECK( ( id2 == id1 ) == false );
       CHECK( ( id2 != id1 ) == true );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::map" ) {
+
+      std::map< ReactionID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ReactionID( "n,Fe56->n,Fe56" ) ] == "1" );
+      CHECK( map[ ReactionID( "n,Fe56->n,Fe56_e1" ) ] == "2" );
+    } // THEN
+
+    THEN( "instances can be used as keys in a std::unordered_map" ) {
+
+      std::unordered_map< ReactionID, std::string > map{
+
+        { id1, "1" }, { id2, "2" }
+      };
+
+      CHECK( map[ id1 ] == "1" );
+      CHECK( map[ id2 ] == "2" );
+      CHECK( map[ ReactionID( "n,Fe56->n,Fe56" ) ] == "1" );
+      CHECK( map[ ReactionID( "n,Fe56->n,Fe56_e1" ) ] == "2" );
     } // THEN
   } // GIVEN
 


### PR DESCRIPTION
This pull request adds hash functions to all identifiers, along with an override for std::hash so that the identifiers can be used as keys in both map and unordered map (and probably hopscotch_map as well).

Tests using map and unordered map were added as well.